### PR TITLE
feat(project): validate dates before casting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-module.exports = {
+module.exports = { 
   /**
    * Detect the type of `value`. Returns 'integer', 'float', 'boolean' or 'string'; defaults to 'string'.
    *
@@ -24,7 +24,7 @@ module.exports = {
     if (value.search(/^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z?$/) > -1) {
       return 'datetime';
     }
-
+ 
     return 'string';
   },
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = {
 
       case 'date':
       case 'datetime':
-        value = new Date(value);
+        if (value) value = new Date(value);
         break;
 
       case 'int':


### PR DESCRIPTION
Fix so that a date is not created if the value is null.

I fixed this because aurelia-orm uses typer, as it will create a date even when the value is null. So I was getting date values where there should be none.